### PR TITLE
Redirect cached wordpress images

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,10 +2,18 @@ var pb_urls = [
   '*://*.photobucket.com/*',
   '*://photobucket.com/*'
 ]
+var wp_urls = [
+  '*://*.wp.com/*.photobucket.com/*',
+  '*://*.wp.com/photobucket.com/*'
+]
 
-var opts = { urls: pb_urls,
-             types: ['image'] }
-chrome.webRequest.onBeforeSendHeaders.addListener( onheaders, opts, ['requestHeaders','blocking'] )
+var pb_opts = { urls: pb_urls,
+                types: ['image'] }
+chrome.webRequest.onBeforeSendHeaders.addListener( onheaders, pb_opts, ['requestHeaders','blocking'] )
+
+var wp_opts = { urls: wp_urls,
+                types: ['image'] }
+chrome.webRequest.onBeforeRequest.addListener( onrequest, wp_opts, ['blocking'] )
 
 function onheaders(info) {
   for (var hdr of info.requestHeaders) {
@@ -15,4 +23,9 @@ function onheaders(info) {
     }
   }
   return { requestHeaders: info.requestHeaders }
+}
+
+function onrequest(info) {
+  var re = /^.+\.wp\.com\/((?:.+\.)?photobucket\.com\/.+)/;
+  return { redirectUrl: info.url.replace(re, 'https://$1') };
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,16 +1,18 @@
 {
   "name": "photobucket embed fix",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "permissions": [
     "webRequest",
     "webRequestBlocking",
     "storage",
     "*://*.photobucket.com/*",
-    "*://photobucket.com/*"
+    "*://photobucket.com/*",
+    "*://*.wp.com/*.photobucket.com/*",
+    "*://*.wp.com/photobucket.com/*"
   ],
   "background": {
     "scripts": ["background.js"]
   },
   "manifest_version":2
-  
+
 }


### PR DESCRIPTION
I found that photobucket images being cached on wordpress blogs were still broken (probably a very common thing) so thought it would be worthwhile adding a redirect to the extension.

Here's an example page: https://treefool.com/

Haven't tested very thoroughly, but seems to do the job!