### PR TITLE
fix referer, es5 -> es6, add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.js]
+indent_style = space
+indent_size = 2
+


### PR DESCRIPTION
Turns out the only dynamic piece needed in the referer is the username. Interestingly, it doesn't even require the part after `.../media/` (e.g. the `cGF0aDovSU1HXzAwMDQtMjkuanBn` as you mentioned in the readme). Fortunately we can grab that the username from request URL. I suspect they won't be able to lock it down much more than this as it would require a db lookup for every variation of referer, which would be rather expensive.

Since this is a chrome extension, I also updated the code to es6 syntax... hope that's alright.

Added the .editorconfig since my editor really doesn't love 2 space indents by default :p